### PR TITLE
Set `parallel_read_safe` to True to enable faster Sphinx builds

### DIFF
--- a/sphinxcontrib/rawfiles.py
+++ b/sphinxcontrib/rawfiles.py
@@ -30,3 +30,5 @@ def on_html_collect_pages(app):
 def setup(app):
     app.add_config_value('rawfiles', [], 'html')
     app.connect("html-collect-pages", on_html_collect_pages)
+    return {"parallel_read_safe": True,
+            "parallel_write_safe": True}


### PR DESCRIPTION
When calling `sphinx-build` with option `-j auto` (= build in parallel), I encounter the following warning when `sphinxcontrib.rawfiles` is enabled:

```
WARNING: the sphinxcontrib.rawfiles extension does not declare if it is safe
for parallel reading, assuming it isn't - please ask the extension author to check
and make it explicit
WARNING: doing serial read
```

This PR changes the extension to declare that it is safe for parallel reading (using the mechanism documented [here](https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata)).

Because `rawfiles` was the only extension blocking my Sphinx project from using parallel read, I find that this change speeds up `sphinx-build` by a factor 3x for me!